### PR TITLE
Refactor: Move get-system-instructions to its own module

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -2,12 +2,13 @@
 
 import { defineAssetTools } from "./tools/assets/assets-tools.js";
 import { defineSceneTools } from "./tools/scene/scene-tools.js";
+import { defineSystemTools } from "./tools/system-tools.js";
 import { startServer, ToolsManager } from "./utils.js";
 
 const manager = new ToolsManager();
 
+defineSystemTools();
 defineSceneTools(manager);
-
 defineAssetTools(manager);
 
 startServer().catch((error) => {

--- a/src/mcp/tools/system-tools.ts
+++ b/src/mcp/tools/system-tools.ts
@@ -1,0 +1,25 @@
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { readFileSync } from "fs";
+import { mcpServer } from "../utils.js";
+
+export function defineSystemTools() {
+
+    mcpServer.tool("get-system-instructions", "Get the system instructions. This is fully required for the LLM to know how to build the arguments of this MCP server tools. Tools like `scene-add-game-objects`, `scene-update-game-objects`, `scene-add-game-object-filters`, `scene-update-game-object-filters`, `scene-add-plain-objects`, and `scene-update-plain-objects` requires that the LLM get the system instructions first to know the tool arguments structure.", () => {
+
+        const __filename = fileURLToPath(import.meta.url);
+
+
+        const text1 = readFileSync(
+            join(dirname(__filename), "prompts/system.md"), "utf-8");
+
+        const text2 = readFileSync(
+            join(dirname(__filename), "prompts/tools.md"), "utf-8");
+
+        return {
+            content: [
+                { type: "text", text: `${text1}\n${text2}` }
+            ],
+        }
+    });
+}

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -21,23 +21,6 @@ export let mcpServer = new McpServer({
     instructions: "The Phaser Editor MCP server exposes a set of tools for automating and extending Phaser Editor v5 through the Model Context Protocol (MCP). To use these tools, ensure Phaser Editor is running and accessible. This server enables integration with LLMs and external clients, allowing you to query, modify, and automate game scenes, assets, tilemaps, and more directly from your MCP-compatible environment.",
 });
 
-mcpServer.tool("get-system-instructions", "Get the system instructions. This is fully required for the LLM to know how to build the arguments of this MCP server tools. Tools like `scene-add-game-objects`, `scene-update-game-objects`, `scene-add-game-object-filters`, `scene-update-game-object-filters`, `scene-add-plain-objects`, and `scene-update-plain-objects` requires that the LLM get the system instructions first to know the tool arguments structure.", () => {
-
-    const __filename = fileURLToPath(import.meta.url);
-
-
-    const text1 = readFileSync(
-        join(dirname(__filename), "tools/prompts/system.md"), "utf-8");
-
-    const text2 = readFileSync(
-        join(dirname(__filename), "tools/prompts/tools.md"), "utf-8");
-
-    return {
-        content: [
-            { type: "text", text: `${text1}\n${text2}` }
-        ],
-    }
-});
 
 export async function startServer() {
 


### PR DESCRIPTION
The 'get-system-instructions' command was previously defined in 'src/mcp/utils.ts', which is not consistent with how other tools are defined.

This change moves the command to its own file, 'src/mcp/tools/system-tools.ts', and registers it in 'src/mcp/index.ts'. This improves the structure and maintainability of the codebase.