### PR TITLE
feat: Implement Mutoid collision and destruction logic

### DIFF
--- a/src/game-objects/bullet.ts
+++ b/src/game-objects/bullet.ts
@@ -4,6 +4,7 @@ export class Bullet extends Phaser.Physics.Arcade.Sprite
 {
     speed;
     id: number = 0;
+    hp: number = 1;
     end_direction = new Phaser.Math.Vector2(0, 0);
 
     constructor(scene, x, y, textureKey = "game_asset", frame = "bullet") {


### PR DESCRIPTION
This commit introduces the complete collision and destruction logic for the Mutoid boss in MutoidScene.

- Player bullets are now managed by a physics group for proper collision detection.
- A tiered damage system has been implemented for the Mutoid:
  - Arms must be destroyed first (10 HP).
  - Then the torso can be damaged (20 HP). Upon destruction, it displays a damaged frame.
  - Finally, the head can be damaged.
- A robust collision system is implemented by creating individual physics bodies for each Mutoid part and synchronizing their positions with the parent container in the `update` loop. This ensures accurate collision detection as the Mutoid moves.
- When the Mutoid's head is destroyed, an animated explosion of spewing heads is triggered.
- The player now has a visual tweening effect (alpha flash) and gamepad vibration upon taking damage to indicate invincibility frames.