### PR TITLE
feat: Add scene selector to PackerScene

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,11 +13,6 @@ import { setupSecretTouchHandler } from "./utils/helper-checkForSecretTouch";
 import { PackerScene } from "./scenes/PackerScene";
 import MutoidScene from "./scenes/MutoidScene";
 
-const SCENE_NAMES = {
-  "MutoidScene": MutoidScene
-};
-
-
 export class GameScene extends Phaser.Scene {
   #startBtn!: Phaser.GameObjects.Sprite;
   player!: Player;
@@ -217,9 +212,17 @@ function onDeviceReady() {
     appElement.setAttribute("style", "display:none");
   }
 
+  const SCENE_NAMES = {
+    "MutoidScene": MutoidScene,
+    "TitleScene": TitleScene,
+    "GameScene": GameScene,
+    "EditorScene": EditorScene,
+    "PackerScene": PackerScene,
+  };
+
   const sceneNameRequested = new URL(window.location.href).searchParams.get("scene");
-  const sceneName = sceneNameRequested && SCENE_NAMES[sceneNameRequested];
-  const scene = sceneName ? [LoadScene, OverloadScene, sceneName] : [LoadScene, OverloadScene, TitleScene, GameScene, EditorScene, PackerScene];
+  const sceneClass = sceneNameRequested && SCENE_NAMES[sceneNameRequested];
+  const scene = sceneClass ? [LoadScene, OverloadScene, sceneClass] : [LoadScene, OverloadScene, TitleScene, GameScene, EditorScene, PackerScene];
 
   globalThis.__PHASER_GAME__ = new Phaser.Game({
     parent: "game",

--- a/src/scenes/PackerScene.ts
+++ b/src/scenes/PackerScene.ts
@@ -89,6 +89,44 @@ export class PackerScene extends Phaser.Scene {
         h1.textContent = 'Atlas Packer - Select or Create Atlas';
         this.editorDiv.appendChild(h1);
 
+        // --- Scene Selector ---
+        const sceneSelectorContainer = document.createElement('div');
+        sceneSelectorContainer.style.cssText = 'margin: 20px 0; background: #111; padding: 15px; border-radius: 5px;';
+
+        const sceneLabel = document.createElement('label');
+        sceneLabel.textContent = 'Go to Scene: ';
+        sceneLabel.style.marginRight = '10px';
+
+        const sceneSelect = document.createElement('select');
+        sceneSelect.style.cssText = 'padding: 8px; font-size: 14px;';
+
+        const scenes = ["MutoidScene", "TitleScene", "GameScene", "EditorScene", "PackerScene"];
+        const currentScene = new URL(window.location.href).searchParams.get("scene") || "PackerScene";
+
+        scenes.forEach(sceneName => {
+            const option = document.createElement('option');
+            option.value = sceneName;
+            option.textContent = sceneName;
+            if (sceneName === currentScene) {
+                option.selected = true;
+            }
+            sceneSelect.appendChild(option);
+        });
+
+        sceneSelect.onchange = (e) => {
+            const selectedScene = (e.target as HTMLSelectElement).value;
+            if (selectedScene) {
+                const url = new URL(window.location.href);
+                url.searchParams.set('scene', selectedScene);
+                window.location.href = url.toString();
+            }
+        };
+
+        sceneSelectorContainer.appendChild(sceneLabel);
+        sceneSelectorContainer.appendChild(sceneSelect);
+        this.editorDiv.appendChild(sceneSelectorContainer);
+        // --- End Scene Selector ---
+
         const closeBtn = document.createElement('button');
         closeBtn.textContent = '✕ Close';
         closeBtn.style.cssText = 'position: absolute; top: 20px; right: 20px; padding: 5px 10px;';


### PR DESCRIPTION
This commit introduces a scene selector dropdown on the secret touch screen (PackerScene).

- A dropdown menu has been added to the top of the PackerScene UI, allowing the user to select and switch to different game scenes (MutoidScene, TitleScene, GameScene, EditorScene, PackerScene).
- The `main.ts` file has been updated to handle a `?scene=` URL query parameter, which allows for direct loading of the specified scene.
- The list of scenes available for direct loading has been expanded to include all major scenes.