### PR TITLE
fix(mutoid): Ensure correct parts fly off on destruction

### DIFF
--- a/src/game-objects/mutoid.ts
+++ b/src/game-objects/mutoid.ts
@@ -324,11 +324,45 @@ export class Mutoid extends Phaser.GameObjects.Container {
 
           this.stopFloatTween();
 
-          head.destroy();
-          this.head = null;
-
           if (this.active) {
-            this.destroy(); // Or trigger a bigger explosion
+            const partsToKeep = [this.head, this.torsoLeft, this.torsoRight, this.treadFrontLeft];
+            const partsToFlyOff = this.getAll().filter(p =>
+              p.active &&
+              !partsToKeep.includes(p as any)
+            );
+            const containerCenter = new Phaser.Math.Vector2(this.x, this.y);
+
+            partsToFlyOff.forEach(part => {
+              const sprite = part as Phaser.GameObjects.Sprite;
+              if (sprite.body) {
+                const body = sprite.body as Phaser.Physics.Arcade.Body;
+                body.setImmovable(false);
+                body.setGravityY(300);
+                body.setAngularVelocity(Phaser.Math.Between(-200, 200));
+
+                const [partWorldX, partWorldY] = this.getWorldCoors(sprite.x, sprite.y);
+
+                const angle = Phaser.Math.Angle.Between(
+                  containerCenter.x,
+                  containerCenter.y,
+                  partWorldX,
+                  partWorldY
+                );
+                const speed = Phaser.Math.Between(150, 250);
+                this.scene.physics.velocityFromRotation(angle, speed, body.velocity);
+
+                this.scene.tweens.add({
+                  targets: sprite,
+                  alpha: 0,
+                  duration: 500,
+                  delay: 1500,
+                  onComplete: () => {
+                    sprite.destroy();
+                  }
+                });
+              }
+            });
+            this.active = false;
           }
 
           const explosionGroup = scene.add.group();


### PR DESCRIPTION
When the Mutoid is defeated, the head, torso, and frontTreadLeft now remain on screen. All other active parts are given physics properties to fly off in an explosion effect before being destroyed.

This change modifies the `handleBulletCollision` method in `src/game-objects/mutoid.ts` to correctly filter which parts to keep and which to discard. The logic for the explosion effect is also refined to be more robust.