### PR TITLE
fix(mutoid): Correct physics initialization to prevent parts detachin…

### DIFF
--- a/src/game-objects/mutoid.ts
+++ b/src/game-objects/mutoid.ts
@@ -50,7 +50,29 @@ export class Mutoid extends Phaser.GameObjects.Container {
     this.animate();
 
     scene.add.existing(this);
-    this.scene.events.on(Phaser.Scenes.Events.UPDATE, this.update, this);
+  }
+
+  preUpdate(time: number, delta: number) {
+    super.preUpdate(time, delta);
+
+    if (!this.active) {
+
+      return;
+    }
+
+    this.list.forEach((part: any) => {
+
+      if (part.body) {
+
+        const body = part.body as Phaser.Physics.Arcade.Body;
+        const p = part as Phaser.GameObjects.Sprite;
+
+        const [worldX, worldY] = this.getWorldCoors(p.x, p.y);
+
+        body.position.x = worldX - p.displayOriginX;
+        body.position.y = worldY - p.displayOriginY;
+      }
+    });
   }
 
   setPlayer(player: Player) {
@@ -190,19 +212,6 @@ export class Mutoid extends Phaser.GameObjects.Container {
       : ["atlas_s1", "atlas_s2", "atlas_s3", "atlas_s3"];
     this.ensureExplicitAnimation("mutoid-head-back", "mutoid-head", headBackFrames, 2, 0);
     if (this.head) this.head.setFrame(HEAD_FRAME);
-  }
-
-  update(...args: any[]) {
-      if (!this.active) return;
-      this.list.forEach((part: any) => {
-        if (part.body) {
-          const body = part.body as Phaser.Physics.Arcade.Body;
-          const p = part as Phaser.GameObjects.Sprite;
-          const [worldX, worldY] = this.getWorldCoors(p.x, p.y);
-          body.position.x = worldX - p.displayOriginX;
-          body.position.y = worldY - p.displayOriginY;
-        }
-      });
   }
 
   getWorldCoors(x: number, y: number): [number, number] {


### PR DESCRIPTION
…g on creation

The previous implementation had a timing issue where the physics bodies of the mutoid's parts were not synchronized with the container before the first physics step. This caused the parts to fly apart immediately upon creation.

This commit moves the physics synchronization logic to the `preUpdate` method, ensuring that the bodies are correctly positioned before the physics simulation runs. The redundant `update` method and its corresponding event listener have been removed.